### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build and test
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
@@ -24,6 +25,7 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
@@ -36,6 +38,7 @@ jobs:
     name: Create a release
     needs: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/create-release@v1

--- a/.github/workflows/scan-detekt.yml
+++ b/.github/workflows/scan-detekt.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2

--- a/.github/workflows/validate-gradle-wrapper.yml
+++ b/.github/workflows/validate-gradle-wrapper.yml
@@ -10,6 +10,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259